### PR TITLE
#/make_incorporated_method_drift_fraction_always_zero

### DIFF
--- a/pwctool/gui_utils.py
+++ b/pwctool/gui_utils.py
@@ -36,7 +36,7 @@ def get_xl_sheet_names(drop_down: QComboBox, text_widget: QLineEdit, error_dialo
         except FileNotFoundError:
             error_dialog.errMsgLabel.setText(fnf_error_messages.get(table, "Unknown Table"))
             error_dialog.exec_()
-        except PermissionError:
+        except PermissionError:  # this happens when apt/drt is open when user loads a config
             error_dialog.errMsgLabel.setText(pm_error_messages.get(table, "Unknown Table"))
             error_dialog.exec_()
         else:

--- a/pwctool/gui_utils.py
+++ b/pwctool/gui_utils.py
@@ -16,9 +16,14 @@ from pwctool.constants import (
 def get_xl_sheet_names(drop_down: QComboBox, text_widget: QLineEdit, error_dialog: QDialog, table: str) -> None:
     """Gets the Excel sheet names for the APT or DRT and updates drop down"""
 
-    error_messages = {
+    fnf_error_messages = {
         "APT": "Invalid Agronomic Practices Table path, please correct and try again.",
         "DRT": "Invalid Drift Reduction Table path, please correct and try again.",
+    }
+
+    pm_error_messages = {
+        "APT": "Please close the Agronomic Practices Table before loading a configuration to avoid permission error and try again.",
+        "DRT": "Please close the Drift Reduction Table before loading a configuration to avoid permission error and try again.",
     }
 
     file_path = text_widget.text()
@@ -29,7 +34,10 @@ def get_xl_sheet_names(drop_down: QComboBox, text_widget: QLineEdit, error_dialo
         try:
             sheets: list = pd.ExcelFile(file_path).sheet_names
         except FileNotFoundError:
-            error_dialog.errMsgLabel.setText(error_messages.get(table, "Unknown Table"))
+            error_dialog.errMsgLabel.setText(fnf_error_messages.get(table, "Unknown Table"))
+            error_dialog.exec_()
+        except PermissionError:
+            error_dialog.errMsgLabel.setText(pm_error_messages.get(table, "Unknown Table"))
             error_dialog.exec_()
         else:
             drop_down.addItems(sheets)

--- a/pwctool/pwct_algo_functions.py
+++ b/pwctool/pwct_algo_functions.py
@@ -16,6 +16,8 @@ import numpy as np
 
 logger = logging.getLogger("adt_logger")  # retrieve logger configured in app_dates.py
 
+from pwctool.constants import BURIED_APPMETHODS
+
 
 def lookup_states_from_crop(
     crop_to_state_lookup_table: pd.DataFrame, run_ag_practices: pd.Series, label_convention_states: dict[str, list[str]]
@@ -69,6 +71,20 @@ def lookup_huc_from_state(state_to_huc_lookup_table: pd.DataFrame, states: list[
     model_hucs = sorted(model_hucs)
 
     return model_hucs
+
+
+def get_drift_profile(run_ag_practices: pd.Series) -> str:
+    """Gets the drift profile associate with the use (row in APT) app method.
+    If the use is specified as an incorporated method (3-7), make sure the
+    drift profile is NODRIFT
+    """
+
+    if run_ag_practices["ApplicationMethod"] in BURIED_APPMETHODS:
+        drift_profile = "NODRIFT"
+    else:
+        drift_profile = run_ag_practices["DriftProfile"]
+
+    return drift_profile
 
 
 def get_all_potential_app_dates(wettest_month_table: pd.DataFrame, huc2: str) -> list:

--- a/pwctool/pwct_algo_thread.py
+++ b/pwctool/pwct_algo_thread.py
@@ -24,6 +24,7 @@ import numpy as np
 from pwctool.pwct_batchfile_qc import qc_batch_file  # pylint: disable=import-error
 from pwctool.pwct_batchfile_qc import standardize_field_names  # pylint: disable=import-error
 from pwctool.pwct_algo_functions import lookup_states_from_crop  # pylint: disable=import-error
+from pwctool.pwct_algo_functions import get_drift_profile  # pylint: disable=import-error
 from pwctool.pwct_algo_functions import lookup_huc_from_state  # pylint: disable=import-error
 from pwctool.pwct_algo_functions import get_all_potential_app_dates  # pylint: disable=import-error
 from pwctool.pwct_algo_functions import get_interval  # pylint: disable=import-error
@@ -35,13 +36,10 @@ from pwctool.pwct_algo_functions import no_more_apps_can_be_made  # pylint: disa
 from pwctool.pwct_algo_functions import derive_instruction_date_restrictions  # pylint: disable=import-error
 
 from pwctool.constants import (
-    ALL_BINS,
     ALL_APPMETHODS,
     BURIED_APPMETHODS,
     ALL_DISTANCES,
-    ALL_DEPTHS,
     FOLIAR_APPMETHOD,
-    TBAND_APPMETHOD,
 )
 
 logger = logging.getLogger("adt_logger")  # retrieve logger configured in app_dates.py
@@ -491,7 +489,7 @@ class PwcToolAlgoThread(qtc.QThread):
             )
             huc2s = lookup_huc_from_state(self.state_to_huc_lookup_table, states)
             application_method = run_ag_pract["ApplicationMethod"]
-            drift_profile = run_ag_pract["DriftProfile"]
+            drift_profile = get_drift_profile(run_ag_pract)
             run_distances = run_distances_all_methods[application_method]
             depths, tband = self.get_app_method_depths_and_tband(application_method)
 

--- a/pwctool/validate_inputs.py
+++ b/pwctool/validate_inputs.py
@@ -111,6 +111,14 @@ def _validate_apt(config: dict[str, Any], error_dialog: QDialog):
         err_message = "You might have the Ag Practices Table open in Excel. Please close it before running."
         _display_error_message(error_dialog, err_message)
         return False
+    except ValueError:
+        if config["APT_SCENARIO"] == "":
+            err_message = "Something is wrong with the specified Ag Practices Table sheet name. Please respecify the Ag Practices Table path and try again."
+            _display_error_message(error_dialog, err_message)
+        else:
+            err_message = "An unknown error occured. Please save the configuration, reload it, and try executing again."
+            _display_error_message(error_dialog, err_message)
+        return False
 
     # check that the first column of the apt is RunDescriptor
     try:

--- a/pwctool/validate_inputs.py
+++ b/pwctool/validate_inputs.py
@@ -111,7 +111,7 @@ def _validate_apt(config: dict[str, Any], error_dialog: QDialog):
         err_message = "You might have the Ag Practices Table open in Excel. Please close it before running."
         _display_error_message(error_dialog, err_message)
         return False
-    except ValueError:
+    except ValueError:  # this should only happen when permission error is handled (apt file is open when config is loaded) and user immediately executes
         if config["APT_SCENARIO"] == "":
             err_message = "Something is wrong with the specified Ag Practices Table sheet name. Please respecify the Ag Practices Table path and try again."
             _display_error_message(error_dialog, err_message)


### PR DESCRIPTION
Ensures that incorporated methods always have drift fraction value of zero and efficiency of 1. This is only necessary if user specifies drift profile other than "NODRIFT" when app method is 3-7 (incorproated).

Handled some other errors that came up during testing. See comments in code.